### PR TITLE
Make flyway executable by anyone

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -395,6 +395,7 @@ rm -rf ngrok-stable-linux-amd64.zip
 
 wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.2.0/flyway-commandline-4.2.0-linux-x64.tar.gz
 tar -zxvf flyway-commandline-4.2.0-linux-x64.tar.gz -C /usr/local
+chmod +x /usr/local/flyway-4.2.0/flyway
 ln -s /usr/local/flyway-4.2.0/flyway /usr/local/bin/flyway
 rm -rf flyway-commandline-4.2.0-linux-x64.tar.gz
 


### PR DESCRIPTION
Flyway is only executable by root. This fixes that.